### PR TITLE
Fix pd.concat() crash when no MIDI files are converted

### DIFF
--- a/midi_to_df_conversion.py
+++ b/midi_to_df_conversion.py
@@ -69,6 +69,11 @@ def midi_files_to_df(
         f"midi_to_df_conversion converted {processed_count} files out of {total_count} to dfs"
     )
 
+    if len(dfs) == 0:
+        raise ValueError(
+            f"midi_to_df_conversion could not convert any of {total_count} files to dataframes"
+        )
+
     return pd.concat(dfs)
 
 


### PR DESCRIPTION
When all MIDI files are skipped (due to skip_suspicious filtering or exceptions), pd.concat([]) would fail with a cryptic "No objects to concatenate" error. Now raises a clear ValueError explaining the issue.