### PR TITLE
Add humanization strength factor to blend original and predicted velos

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,23 @@ Then -- making sure you're still in the midihum/ directory -- simply:
 ```shell
 python main.py humanize /path/to/file.mid /path/to/humanized_file.mid
 ```
-
 (Or use `python3` instead of `python` if that is your Python 3 binary.)
+
+### Adjusting Humanization Strength (added later by joney94)
+
+You can adjust how much the tool changes the original dynamics using the `--strength` (or `-s`) parameter:
+
+```shell
+python main.py humanize input.mid output.mid --strength 0.5
+```
+
+The strength is a value between `0.0` and `1.0`:
+- `1.0` (default): Fully replaces original velocities with model predictions.
+- `0.0`: Keeps original velocities (no humanization).
+- `0.5`: Blends original and humanized velocities 50/50.
+
+This is particularly useful if your source MIDI comes from **notation software** (like Sibelius, Finale, or Musescore). These programs often export "discrete" velocity values (e.g., all *mf* notes are exactly 80). By using a strength value like `0.3` or `0.5`, you can preserve your intended musical dynamics (the difference between parts) while adding the subtle, natural variations of a human performer.
+
 
 ## Performance
 

--- a/main.py
+++ b/main.py
@@ -40,11 +40,17 @@ def find_midi_duplicates(target_dir: str):
 @midihum.command()
 @click.argument("source")
 @click.argument("destination")
-def humanize(source: str, destination: str):
+@click.option(
+    "--strength",
+    "-s",
+    default=1.0,
+    help="How much to humanize (0.0 = original, 1.0 = fully humanized).",
+)
+def humanize(source: str, destination: str, strength: float):
     """Humanize MIDI file at SOURCE, writing to DESTINATION."""
     assert source != destination, (source, destination)
     try:
-        MidihumModel().humanize(Path(source), Path(destination))
+        MidihumModel().humanize(Path(source), Path(destination), strength=strength)
     except Exception as e:
         click.echo(f"midihum could not humanize the given file: {e}")
 

--- a/midihum_model.py
+++ b/midihum_model.py
@@ -107,9 +107,9 @@ class MidihumModel:
         return df
 
     def humanize(
-        self, source_path: Path, destination_path: Path, rescale: bool = True
+        self, source_path: Path, destination_path: Path, strength: float = 1.0
     ) -> List[float]:
-        click.echo(f"midihum_tabular humanizing {source_path}")
+        click.echo(f"midihum_tabular humanizing {source_path} with strength {strength}")
         df = midi_files_to_df(
             midi_filepaths=[source_path], skip_suspicious=False
         ).copy()
@@ -119,13 +119,22 @@ class MidihumModel:
 
         # load input midi file and, for each prediction, set the new velocity
         midi_file = mido.MidiFile(source_path)
-        velocities = [round(row.prediction) for _, row in df.iterrows()]
-        for row, velocity in zip(df.itertuples(), velocities):
+        
+        final_velocities = []
+        for row in df.itertuples():
+            original = row.velocity
+            predicted = row.prediction
+            
+            # Interpolate between original and predicted velocity
+            blended = original + strength * (predicted - original)
+            velocity = int(round(np.clip(blended, 1, 127)))
+            
             midi_file.tracks[row.midi_track_index][
                 row.midi_event_index
             ].velocity = velocity
+            final_velocities.append(velocity)
 
         click.echo(f"midihum_tabular saving humanized file to {destination_path}")
         midi_file.save(destination_path)
 
-        return velocities
+        return final_velocities


### PR DESCRIPTION
Hi, 
This pull request introduces a small new feature hat allows users to control how strongly the MIDI humanization is applied, making the tool more flexible for different use cases. The main changes include adding a `--strength` parameter to the CLI, updating the humanization logic to blend original and predicted velocities, and improving documentation to explain the new feature.

Example Use Case: If I write Music in Notation Software and Add Dynamics to it (piano, mezzoforte, forte and so on), then the notation software assigns different velocity values according to the dynamics, e.g. "50" for each note with a "p" on it, "107" for every "forte" note. With the new "strength" parameter, I can partly take these dynamics into account instead of completely overwriting it with the predicted values from your tool.

Thanks for your helpful tool by the way, works nicely :))